### PR TITLE
Provide a description, change extension type to "parserhook"

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -2,10 +2,10 @@
 	"name": "OSMCAL Wiki Widget",
 	"author": "Thomas Skowron",
 	"url": "https://github.com/thomersch/OSMCALWikiWidget",
-	"description": "",
+	"description": "Display OpenStreetMap's events from [//osmcal.org osmcal.org]",
 	"version": "0.1",
 	"license-name": "Apache-2.0",
-	"type": "variable",
+	"type": "parserhook",
 	"AutoloadClasses": {
 		"OSMCALWidget": "includes/OSMCALWidget.php"
 	},


### PR DESCRIPTION
I provided a description, so one can quickly see what the extension does by looking at "Special:Version". The description uses wiki markup, which is supported. 
The extension creates a new tag ```<osmcal/>``` and thus it is a "parserhook" type extension (explanation: https://www.mediawiki.org/wiki/Manual:Extension.json/Schema#type). It actually just changes the appearance on "Special:Version" page, but for the sake of correctness... 