### PR TITLE
Allow usage of "around" directly from within MediaWiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ It has three optional parameters:
 - `in`: Limits displayed events to a certain country, e.g. `<osmcal in="de" />` will display events in Germany.
 - `lang`: Sends the given language code to the API, thus formatting the dates in the specified language, e.g. `<osmcal lang="fr" />` will display all upcoming worldwide events, with the dates in French.
 - `nobanner`: Doesn't display the "Add to OpenStreetMap Calendar banner" at the bottom, e.g. `<osmcal nobanner />`.
+- `around`: Specify the centerpoint of the area of which events should be displayed. A hardcoded radius of 50km is queried. The format of the parameter is "<lat>,<lon>".

--- a/includes/OSMCALWidget.php
+++ b/includes/OSMCALWidget.php
@@ -23,6 +23,7 @@ class OSMCALWidget {
 			$banner = false;
 		}
 
+		// Parameter around=<lat>,<lon>
 		if (array_key_exists('around', $args)) {
 			$req_params = "?around=".$args['around'];
 		}

--- a/includes/OSMCALWidget.php
+++ b/includes/OSMCALWidget.php
@@ -23,6 +23,10 @@ class OSMCALWidget {
 			$banner = false;
 		}
 
+		if (array_key_exists('around', $args)) {
+			$req_params = "?around=".$args['around'];
+		}
+
 		$req_opts = [
 			"http" => [
 				"method" => "GET",


### PR DESCRIPTION
The parameter "around" can now be specified as parameter of the osmcal-MediaWiki object. Its value is then used to create the OsmCal-URL.
Would solve #179 and maybe also #7